### PR TITLE
Fix tcp timeout

### DIFF
--- a/scripts/NucleusDriver.py
+++ b/scripts/NucleusDriver.py
@@ -886,9 +886,9 @@ class NucleusDriver:
 
                 try:
                     self.tcp = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
-                    self.tcp.connect((self.tcp_configuration.host, self.tcp_configuration.port))
                     self.tcp.settimeout(self.timeout)
-
+                    self.tcp.connect((self.tcp_configuration.host, self.tcp_configuration.port))
+                    
                 except Exception as exception:
                     self.messages.write_exception(message='Failed to connect through TCP: {}'.format(exception))
                     return False


### PR DESCRIPTION
Tested the driver without the device connected and the timeout would not trigger for TCP. Easy fix by setting the timeout before trying to connect :smile: 